### PR TITLE
Use a height of 48px instead of 36px

### DIFF
--- a/stylesheet.css
+++ b/stylesheet.css
@@ -1,8 +1,8 @@
 #message-tray {
     background-position: 0 0;
-    height: 36px;
+    height: 48px;
 }
 
 .message-tray-summary {
-    height: 36px;
+    height: 48px;
 }


### PR DESCRIPTION
For me, 36px is too small, and the border around the icon is not consistent with the border at the sides.  Resizing it to 48px fixes this for me:

![](http://i.imgur.com/kZ4UOtg.png)
